### PR TITLE
Allow JSON highlighting for any content type (***/***json). 

### DIFF
--- a/syntaxes/apib.tmLanguage
+++ b/syntaxes/apib.tmLanguage
@@ -48,7 +48,7 @@
       <key>name</key>
       <string>blueprint.response.json</string>
       <key>begin</key>
-      <string>([-+*]) ([Rr]equest|[Rr]esponse) (\d+)?(?: (\(.*\/+json(?:[ ;\/]+.*)?\)))+</string>
+      <string>([-+*]) ([Rr]equest|[Rr]esponse) (\d+)?(?: (\(.*\/+.*json(?:[ ;\/]+.*)?\)))+</string>
       <key>end</key>
       <string>^(?=\S)</string>
       <key>beginCaptures</key>


### PR DESCRIPTION
This allows json highlighting for the JSON:API content type: (application/vnd.api+json) 